### PR TITLE
fix: show two columns on medium screens

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -64,7 +64,7 @@ const About = () => {
       <section className="py-10 bg-gray-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <h2 className="text-3xl font-bold text-center text-gray-900 mb-8">Our Team</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
             {/*
               Team member data should ideally come from a CMS or database
               This is just placeholder data


### PR DESCRIPTION
## Summary
- display the team section in two columns on medium screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars and no-undef errors in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_689687b43d188330a403d3b01e82e6b1